### PR TITLE
Remove journalctl parser block

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -1,12 +1,4 @@
 <source>
-  @type tcp
-  format journalctl
-  tag journalctl
-  port 5170
-  bind 0.0.0.0
-</source>
-
-<source>
   @type syslog
   format everydayhero
   tag system


### PR DESCRIPTION
```
[error]: config error file="/fluentd/etc/fluent.conf" error="Unknown format template 'journalctl'"
```
